### PR TITLE
Crud competiton api

### DIFF
--- a/Document/models.py
+++ b/Document/models.py
@@ -64,3 +64,19 @@ class User(AbstractUser):
     class Meta:
         db_table = 'User'
 
+
+class Competition(models.Model):
+    name = models.CharField(max_length=255)
+    detail = models.TextField()
+    data_path = models.CharField(max_length=255)
+    created_user = models.CharField(max_length=255)
+    created_date = models.DateTimeField(auto_now_add=True)
+    start_at = models.DateTimeField()
+    end_at = models.DateTimeField()
+
+    def __str__(self):
+        return self.name
+    
+    class Meta:
+        db_table = "Competition"
+

--- a/Document/serialisers.py
+++ b/Document/serialisers.py
@@ -30,3 +30,4 @@ class CompetitionSerializer(serializers.ModelSerializer):
     class Meta:
         model = Competition
         fields = ('id', 'name', 'detail', 'data_path', 'created_user', 'created_date', 'start_at', 'end_at')
+

--- a/Document/serialisers.py
+++ b/Document/serialisers.py
@@ -1,6 +1,6 @@
 from rest_framework import serializers
 
-from Document.models import Document, User, Category
+from Document.models import Document, User, Category, Competition
 
 
 class DocumentSerializer(serializers.ModelSerializer):
@@ -25,3 +25,8 @@ class CategorySerializer(serializers.ModelSerializer):
     class Meta:
         model = Category
         fields = ('category_id', 'category_name')
+
+class CompetitionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Competition
+        fields = ('id', 'name', 'detail', 'data_path', 'created_user', 'created_date', 'start_at', 'end_at')

--- a/Document/urls.py
+++ b/Document/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from . import views
-from .views import UserRegisterView, UserLoginView
+from .views import UserRegisterView, UserLoginView,CompetitionListCreateView, get_all_competitions,update_competition,delete_competition
 
 urlpatterns = [
     path('register', UserRegisterView.as_view(), name='register'),
@@ -10,5 +10,10 @@ urlpatterns = [
     path('documents/<int:pk>', views.UpdateDeleteDocumentView.as_view()),
     path('category/<int:pk>', views.DeleteCategoryView.as_view()),
     path('update/<int:pk>/', views.UpdateCategoryView.as_view(), name='update-category'),
+    path('competitions/', CompetitionListCreateView.as_view(), name='competition-list-create'),
+    path('competitions/all', views.get_all_competitions, name='get_all_competitions'),
+    path('competition/<int:id>/update/', views.update_competition, name='update_competition'),
+    path('competition/<int:id>/delete/', views.delete_competition, name='delete_competition')
+
 
 ]

--- a/Document/urls.py
+++ b/Document/urls.py
@@ -12,8 +12,8 @@ urlpatterns = [
     path('update/<int:pk>/', views.UpdateCategoryView.as_view(), name='update-category'),
     path('competitions/', CompetitionListCreateView.as_view(), name='competition-list-create'),
     path('competitions/all', views.get_all_competitions, name='get_all_competitions'),
-    path('competition/<int:id>/update/', views.update_competition, name='update_competition'),
-    path('competition/<int:id>/delete/', views.delete_competition, name='delete_competition')
+    path('competition/<int:competition_id>/update/', views.update_competition, name='update_competition'),
+    path('competition/<int:competition_id>/delete/', views.delete_competition, name='delete_competition')
 
 
 ]

--- a/Document/views.py
+++ b/Document/views.py
@@ -10,8 +10,10 @@ from rest_framework.views import APIView
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
 from Document.models import Document
-from .models import Category
-from Document.serialisers import DocumentSerializer, UserSerializer, UserLoginSerializer, CategorySerializer
+from .models import Category, Competition
+from Document.serialisers import DocumentSerializer, UserSerializer, UserLoginSerializer, CategorySerializer,CompetitionSerializer
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework import generics
 
 class CreateCategory(ListCreateAPIView):   
     model = Category
@@ -170,3 +172,49 @@ class UpdateCategoryView(RetrieveUpdateDestroyAPIView):
         return JsonResponse({
             'message': 'Update Category unsuccessful!'
         }, status=status.HTTP_400_BAD_REQUEST)
+    
+class CompetitionListCreateView(generics.ListCreateAPIView):
+    queryset = Competition.objects.all()
+    serializer_class = CompetitionSerializer
+    
+def get_all_competitions(request):
+    competitions = list(Competition.objects.all().values())
+    return JsonResponse(competitions, safe=False)
+
+def update_competition(request, competition_id):
+    try:
+        competition = Competition.objects.get(id=competition_id)
+    except Competition.DoesNotExist:
+        return JsonResponse({'error': 'Competition does not exist.'}, status=404)
+
+    if request.method == 'PUT':
+        # update competition fields based on request data
+        competition.name = request.POST.get('name', competition.name)
+        competition.detail = request.POST.get('detail', competition.detail)
+        competition.data_path = request.POST.get('data_path', competition.data_path)
+        competition.start_at = request.POST.get('start_at', competition.start_at)
+        competition.end_at = request.POST.get('end_at', competition.end_at)
+
+        # save updated competition to database
+        competition.save()
+
+        return JsonResponse({'message': 'Competition updated successfully.'}, status=200)
+
+    return JsonResponse({'error': 'Invalid request method.'}, status=400)
+
+@csrf_exempt
+def delete_competition(request, competition_id):
+    try:
+        competition = Competition.objects.get(id=competition_id)
+    except Competition.DoesNotExist:
+        return JsonResponse({'error': 'Competition does not exist.'}, status=404)
+
+    if request.method == 'DELETE':
+        # delete competition from database
+        competition.delete()
+
+        return JsonResponse({'message': 'Competition deleted successfully.'}, status=200)
+
+    return JsonResponse({'error': 'Invalid request method.'}, status=400)
+
+


### PR DESCRIPTION
# What does this PR solve and how
## What is this PR about?
CRUD for competition API

## How to run it step by step
Step 1: in document app/ models.py

```

class Competition(models.Model):
    name = models.CharField(max_length=255)
    detail = models.TextField()
    data_path = models.CharField(max_length=255)
    created_user = models.CharField(max_length=255)
    created_date = models.DateTimeField(auto_now_add=True)
    start_at = models.DateTimeField()
    end_at = models.DateTimeField()

    def __str__(self):
        return self.name
    
    class Meta:
        db_table = "Competition"
```

Step 2: views.py
```
class CompetitionListCreateView(generics.ListCreateAPIView):
    queryset = Competition.objects.all()
    serializer_class = CompetitionSerializer
    
def get_all_competitions(request):
    competitions = list(Competition.objects.all().values())
    return JsonResponse(competitions, safe=False)

@api_view(['DELETE'])
def delete_competition(request, competition_id):
    try:
        competition = Competition.objects.get(id=competition_id)
    except Competition.DoesNotExist:
        return Response({'error': 'Competition does not exist.'}, status=status.HTTP_404_NOT_FOUND)

    competition.delete()
    return Response({'message': 'Competition deleted successfully.'}, status=status.HTTP_200_OK)

@api_view(['PUT'])
def update_competition(request, competition_id):
    try:
        competition = Competition.objects.get(id=competition_id)
    except Competition.DoesNotExist:
        return Response({'error': 'Competition does not exist.'}, status=status.HTTP_404_NOT_FOUND)

    serializer = CompetitionSerializer(competition, data=request.data)
    if serializer.is_valid():
        serializer.save()
        return Response(serializer.data, status=status.HTTP_200_OK)
    return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
```

Step 3: urls.py
```

 path('competitions/', CompetitionListCreateView.as_view(), name='competition-list-create'),
  path('competitions/all', views.get_all_competitions, name='get_all_competitions'),
  path('competition/<int:competition_id>/update/', views.update_competition, name='update_competition'),
  path('competition/<int:competition_id>/delete/', views.delete_competition, name='delete_competition')

```

Step 4: serializers.py

```
class CompetitionSerializer(serializers.ModelSerializer):
    class Meta:
        model = Competition
        fields = ('id', 'name', 'detail', 'data_path', 'created_user', 'created_date', 'start_at', 'end_at')
```


# Implementation 

Add any implementation details
- design patterns used
- any new libs added
- algorithmic overview
- how is the error handling implemented
- observability of the code (monitoring/logging)

# Testing
1. Create Competitions

`http://127.0.0.1:8000/api/competitions/`
<img width="1487" alt="Screen Shot 2023-04-21 at 10 45 03 PM" src="https://user-images.githubusercontent.com/127987939/233765265-9e2c28db-8ae1-4132-8b71-e0fd1fd7dc6b.png">

2. Get competitions

<img width="1483" alt="Screen Shot 2023-04-21 at 10 46 41 PM" src="https://user-images.githubusercontent.com/127987939/233765313-6906807b-358e-4eec-bf81-c57b378423c0.png">

`http://127.0.0.1:8000/api/competitions/all`

<img width="1485" alt="Screen Shot 2023-04-21 at 10 47 26 PM" src="https://user-images.githubusercontent.com/127987939/233765346-8f52c3ac-e207-45c3-b4a8-76ba54e7d3fe.png">

3. Update Competion API
`http://127.0.0.1:8000/api/competition/2/update/`

<img width="1477" alt="Screen Shot 2023-04-21 at 10 48 17 PM" src="https://user-images.githubusercontent.com/127987939/233765366-33b1156a-4354-4635-8f89-f1f7dd6b5a71.png">

4. Delete Competition API:
`http://127.0.0.1:8000/api/competition/2/delete/`

<img width="1486" alt="Screen Shot 2023-04-21 at 10 49 09 PM" src="https://user-images.githubusercontent.com/127987939/233765397-3b2b691d-0257-4287-878b-ac73ec6963b2.png">



#Risk
- 

# Dependencies
- 

# PR Checklist
- [x] Documentation
- [x] Unit testing passed
- [ ] Code review and discussion
- [x] Approve
- [x] Merge
